### PR TITLE
Add custom SPF variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ data "aws_route53_zone" "SES_domain" {
 | receive\_s3\_prefix | The key prefix of the S3 bucket to store received emails. | string | n/a | yes |
 | route53\_zone\_id | Route53 host zone ID to enable SES. | string | n/a | yes |
 | ses\_rule\_set | Name of the SES rule set to associate rules with. | string | n/a | yes |
+| custom\_spf | For those needing more than just the Amazon SPF. The ability to override and take-control. | string | `"v=spf1 include:amazonses.com -all"` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@
  * Creates the following resources:
  *
  * * MX record pointing to AWS's SMTP endpoint
- * * TXT record for SPF validation
+ * * TXT record(s) for SPF validation
  * * Custom MAIL FROM domain
  * * CNAME records for DKIM verification
  * * SES Verfication for the domain
@@ -122,7 +122,7 @@ resource "aws_route53_record" "spf_mail_from" {
   name    = aws_ses_domain_mail_from.main.mail_from_domain
   type    = "TXT"
   ttl     = "600"
-  records = ["v=spf1 include:amazonses.com -all"]
+  records = ["${var.custom_spf}"]
 }
 
 resource "aws_route53_record" "spf_domain" {
@@ -130,7 +130,7 @@ resource "aws_route53_record" "spf_domain" {
   name    = var.domain_name
   type    = "TXT"
   ttl     = "600"
-  records = ["v=spf1 include:amazonses.com -all"]
+  records = ["${var.custom_spf}"]
 }
 
 # Sending MX Record

--- a/variables.tf
+++ b/variables.tf
@@ -49,3 +49,10 @@ variable "enable_incoming_email" {
   type        = "string"
   default     = true
 }
+
+variable "custom_spf" {
+  description = "If you use other third-party email services, you might use this to ensure you only have a single DNS SPF record"
+  type        = "string"
+  default     = "v=spf1 include:amazonses.com -all"
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -46,13 +46,13 @@ variable "ses_rule_set" {
 
 variable "enable_incoming_email" {
   description = "Control whether or not to handle incoming emails"
-  type        = "string"
+  type        = string
   default     = true
 }
 
 variable "custom_spf" {
   description = "If you use other third-party email services, you might use this to ensure you only have a single DNS SPF record"
-  type        = "string"
+  type        = string
   default     = "v=spf1 include:amazonses.com -all"
 }
 


### PR DESCRIPTION
At work we use customer.io. I imagine many will have a wider remit than simply SES. This will allow such users to customize their SPF record